### PR TITLE
add yardoc under Ruby documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A place to organize style guides, best practices, tools, and techniques for Stanford University's Digital Library Systems &amp; Services Group.
 
  - [Best Practices](/best-practices)
+   - [Documentation](/best-practices/documentation)
  - [Style](/style)
  - [Code Review](/code-review)
 

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -1,5 +1,7 @@
 # Best Practices
 
+- [Documentation](/documentation)
+
 Best practices guides should attempt to answer the question:
 
 To what extent does it make our products better?

--- a/best-practices/documentation/README.md
+++ b/best-practices/documentation/README.md
@@ -1,0 +1,10 @@
+# Documentation
+
+## Ruby
+Ruby projects should use [YARD](http://yardoc.org/) for documentation purposes.
+
+[Getting Started with YARD](http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md)
+
+One benefit is YARD runs a live documentation server for the community, hosting docs for all RubyGems and Github projects. The project is at [RubyDoc.info](http://www.rubydoc.info/) (formerly rdoc.info)
+
+A [useful Yardoc cheatsheet](https://gist.github.com/chetan/1827484)


### PR DESCRIPTION
Starts to address #11 

Most likely there will be different documentation standards for different languages. Specifically in mind here is JavaScript