### PR TITLE
links to a section for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ A place to organize style guides, best practices, tools, and techniques for Stan
 
  - [Best Practices](/best-practices)
    - [Documentation](/best-practices/documentation)
+   - [How To - Readme](/best-practices/howto_readme.md)
+   - [Licensing](/best-practices/licensing.md)
+   - [Version Control](/best-practices/version_control.md)
  - [Style](/style)
  - [Code Review](/code-review)
 

--- a/best-practices/README.md
+++ b/best-practices/README.md
@@ -1,6 +1,9 @@
 # Best Practices
 
-- [Documentation](/documentation)
+- [Documentation](/best-practices/documentation)
+- [How To - Readme](/best-practices/howto_readme.md)
+- [Licensing](/best-practices/licensing.md)
+- [Version Control](/best-practices/version_control.md)
 
 Best practices guides should attempt to answer the question:
 


### PR DESCRIPTION
This pull request:

 - fixes the "Documenatation" link
 - adds links in the index readme for other sections

Links are ordered alphabetically. Let's worry about organization later.