### PR TITLE
Add rationale for code review that integrates the role of style guides.

### DIFF
--- a/code-review/README.md
+++ b/code-review/README.md
@@ -1,78 +1,22 @@
-Code Review
-===========
+Code Review and Style Guides
+============================
 
-Enthusiastically copied from https://github.com/thoughtbot/guides/blob/master/code-review/README.md
+We want to write maintainable, bug-free code as a means to maximize our mandatory fun at work. It is more fun to work with code you consider maintainable and readable; having standards around the definitions of these qualities is a worthy endeavor, especially in a group as large as ours (software developers in DLSS). Code review is one tool for this.
 
-A guide for reviewing code and having your code reviewed.
+Code reviews, at their best, help create readable, maintainable, well tested code. We hope to provide some guidelines to all reviewers that will favor productivity without detracting from code readability or maintainability. Similarly, there are expectations of code that is submitted for review.
 
-Everyone
---------
+Technologies that can facilitate these goals include: tests, code coverage, code dependency checkers (such as gemnasium and bundle-audit), and style guide tools such as rubocop.
 
-* Accept that many programming decisions are opinions. Discuss tradeoffs, which
-  you prefer, and reach a resolution quickly.
-* Ask questions; don't make demands. ("What do you think about naming this
-  `:user_id`?")
-* Ask for clarification. ("I didn't understand. Can you clarify?")
-* Avoid selective ownership of code. ("mine", "not mine", "yours")
-* Avoid using terms that could be seen as referring to personal traits. ("dumb",
-  "stupid"). Assume everyone is attractive, intelligent, and well-meaning.
-* Be explicit. Remember people don't always understand your intentions online.
-* Be humble. ("I'm not sure - let's look it up.")
-* Don't use hyperbole. ("always", "never", "endlessly", "nothing")
-* Don't use sarcasm.
-* Keep it real. If emoji, animated gifs, or humor aren't you, don't force them.
-  If they are, use them with aplomb.
-* Talk in person if there are too many "I didn't understand" or "Alternative
-  solution:" comments. Post a follow-up comment summarizing offline discussion.
+Style-related choices can be a source of contention in the code review process; one goal of the Developer Playbook is to reduce conflict around style guides. Style guides have a place in professional software development organizations, helping to reduce the number of bugs and improve readability and maintainability across constantly changing projects and teams in an area where developers do not always agree; as we know, some developers care more deeply about code style than others do and we should expect that to be the case in DLSS where we have a large and diverse group of developers.
 
-Having Your Code Reviewed
--------------------------
+The point of the style guide is not to privilege one person’s preferences or values over another’s but rather to reflect consensus among DLSS developers — and that, as a living document, should change over time according to an open, inclusive process that reflects our norms as they evolve.
 
-* Be grateful for the reviewer's suggestions. ("Good call. I'll make that
-  change.")
-* Don't take it personally. The review is of the code, not you.
-* Explain why the code exists. ("It's like that because of these reasons. Would
-  it be more clear if I rename this class/file/method/variable?")
-* Extract some changes and refactorings into future tickets/stories.
-* Link to the code review from the ticket/story. ("Ready for review:
-  https://github.com/organization/project/pull/1")
-* Push commits based on earlier rounds of feedback as isolated commits to the
-  branch. Do not squash until the branch is ready to merge. Reviewers should be
-  able to read individual updates based on their earlier feedback.
-* Seek to understand the reviewer's perspective.
-* Try to respond to every comment.
-* Wait to merge the branch until Continuous Integration (TDDium, TravisCI, etc.)
-  tells you the test suite is green in the branch.
-* Merge once you feel confident in the code and its impact on the project.
+Absent a group style guide, style-related differences raised (potentially many times) in pull requests can cause delays that seem arbitrary and punitive, especially when they hold up merging long enough that a developer must rebase their work one or more times. This discussion about style is a good one to have — ideally before the pull request has been submitted. A style guide can help here, and allows developers involved with code review to focus on deeper concerns such as improvements to the algorithms and patterns employed.
 
-Reviewing Code
---------------
+Code review is a valuable practice for DLSS developers as we work together to improve our collective codecraft. That said, we should embrace that we are not our code and we should be open to constructive criticism about code that we write in terms of algorithms and patterns used and also in terms of others’ assessment of how readable, or confusing, the code we commit is.
 
-Understand why the code is necessary (bug, user experience, refactoring). Then:
+With a group as large as ours, a style guide can play a significant role in focusing our code review process and helping us be happier developers. This is especially true factoring in how much of our work is embedded in open-source communities such as Hydra, where style guides are already commonly used — and which we should expect to be more involved with as we work towards greater alignment with open-source communities (e.g., Hydra) at DLSS.
 
-* Communicate which ideas you feel strongly about and those you don't.
-* Identify ways to simplify the code while still solving the problem.
-* If discussions turn too philosophical or academic, move the discussion offline
-  to a regular Developer's Forum meeting or create an issue in [DeveloperPlaybook](https://github.com/sul-dlss/DeveloperPlaybook/issues). In the meantime, let the
-  author make the final decision on alternative implementations.
-* Offer alternative implementations, but assume the author already considered
-  them. ("What do you think about using a custom validator here?")
-* Seek to understand the author's perspective.
-* Sign off on the pull request with a :thumbsup: or "Ready to merge" comment.
+The Developer Playbook puts in place a set of processes and practices — e.g., using code review via GitHub pull requests aided by style guides that promote readability and maintainability — that advances management of our many codebases in DLSS in a way that reflects our culture and our norms.
 
-Style Comments
---------------
-
-Reviewers should comment on missed [style](../style)
-guidelines. Example comment:
-
-    [Style](../style):
-
-    > Order resourceful routes alphabetically by name.
-
-An example response to style comments:
-
-    Whoops. Good catch, thanks. Fixed in a4994ec.
-
-If you disagree with a guideline, create an issue in [DeveloperPlaybook](https://github.com/sul-dlss/DeveloperPlaybook/issues) rather than
-debating it within the code review. In the meantime, apply the guideline.
+**N.B.** Developers need management to accept that arriving at and following shared practices such as style guides is going to increase costs (e.g., development time) at least at the outset, and managers should explicitly support developers taking the time necessary to follow these practices. Developers should be empowered to follow shared practices, and we should make sure to surface (e.g., in developer forums or X-Team Sprint Leads meetings) what we need from managers to succeed at following shared practices.


### PR DESCRIPTION
Prior content in the README will be reworked and re-added in a subsequent PR.