### PR TITLE
deployment: add note about database names and deployment names

### DIFF
--- a/best-practices/deployment.md
+++ b/best-practices/deployment.md
@@ -24,3 +24,5 @@ We use different Capistrano environments for each environment we deploy to. Thes
 - `dev`
 - `stage`
 - `prod`
+
+NOTE:  if there is a database, you will likely need to use `development` and `production` to match the database names on the servers.


### PR DESCRIPTION
bumped into this problem with digital stacks.  Capistrano apparently defaults to the stage name as the database name ...
