### PR TITLE
Add honeybadger docs

### DIFF
--- a/best-practices/monitoring.md
+++ b/best-practices/monitoring.md
@@ -1,0 +1,18 @@
+# Monitoring
+
+## Honeybadger
+We use [Honeybadger](https://www.honeybadger.io/) to monitor application exceptions and deployments. (Note: Here are some dlss specific instruction on how to install honeybadger)
+
+Add the honeybadger gem to your existing repo. Bundle install the honeybadger gem in your repo, and require 'capistrano/honeybadger' in your Capfile. 
+
+Go to [honeybadger UI](https://app.honeybadger.io/projects) and click "Add a Project".
+
+The [honeybadger docs](https://docs.honeybadger.io/ruby/integration-guides/rails-exception-tracking.html) contain instructions for how to set it up in a Rails application, but there is a wrinkle to consider as you do so. The instructions point out that installing will "[g]enerate a config/honeybadger.yml file. If you don't like config files, you can place your API key in the $HONEYBADGER_API_KEY environment variable."
+
+If you decide on the former approach, you will want to set up your honeybadger config file in [sul-dlss/shared_configs](https://github.com/sul-dlss/shared_configs). If you would like to use environment variables instead, you will need some assistance from operations to encrypt your project's API key and set up the necessary environment variables via [sul-dlss/puppet](https://github.com/sul-dlss/puppet).
+
+### Slack Integrations
+
+- In the Slack application go to the side bar under `Direct Messages` and click on the Honeybadger application. This should pop up a right side bar where you can click Settings. Then click on "Add Configuration". Then follow the instructions given.
+- Set up a configuration with your PROD environment to the deploy channel.
+- If you don't have any Environments showing, you will need to deploy your application to a VM via capistrano.

--- a/best-practices/setting_up_rails_projects.md
+++ b/best-practices/setting_up_rails_projects.md
@@ -15,6 +15,9 @@ Projects should have implemented continuous integration. The following services 
  - [hound-ci](https://houndci.com/repos) for style checking
  - [coveralls](https://coveralls.io/) for code coverage
 
+## Application Monitoring
+See [Monitoring](/best-practices/monitoring.md).
+
 ## Database
 Use the default `database.yml` from Rails unless there is a reason not to. Prefer to not tie your project to a specific SQL implementation unless necessary. You should use Rails migrations to specify and manage your database schema.
 
@@ -22,4 +25,3 @@ Use the default `database.yml` from Rails unless there is a reason not to. Prefe
 Rails projects in DLSS should use the [RSpec Rails](https://github.com/rspec/rspec-rails) framework for Ruby testing. Much of the [Blacklight](http://projectblacklight.org/) and [Project Hydra](https://projecthydra.org/) community have chosen to use RSpec, we should be consistent unless there is a reason not to.
 
 JavaScript should also be tested. Rails projects have had success in using [teaspoon](https://github.com/modeset/teaspoon) for this.
-


### PR DESCRIPTION
When we are setting up a new rails project, we should use Honeybadger for application monitoring. Otherwise, we can't keep track of an applications exceptions or deployments as easily.

paired w/ @tallenaz 