### PR TITLE
Fix broken link to setting_up_rails_projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A place to organize style guides, best practices, tools, and techniques for Stan
    - [Documentation](/best-practices/documentation)
    - [How To - Readme](/best-practices/howto_readme.md)
    - [Licensing](/best-practices/licensing.md)
-   - [Setting up Rails projects](/best-practices/setting_up_rails_project.md)
+   - [Setting up Rails projects](/best-practices/setting_up_rails_projects.md)
    - [Version Control](/best-practices/version_control.md)
  - [Style](/style)
  - [Code Review](/code-review)


### PR DESCRIPTION
Add missing "s" in the link to setting_up_rails_projects