### PR TITLE
Move Developer onboarding docs to github

### DIFF
--- a/developer_onboarding.md
+++ b/developer_onboarding.md
@@ -1,0 +1,95 @@
+# Developer Onboarding
+The official onboarding process will take six weeks, after which we will be able to gather feedback about the process and collect changes for the next time. We recognize that mentoring a new developer is an important job that will require the mentor to take significant time off their regular work. Training a new hire is not just the responsibility of the supervisor and mentor, but the entire team. However, mentors are expected to take ownership of the process.  DLSS' technology stack and project portfolios are large and complicated, so try to pace the new developer carefully so he or she doesn’t feel as if they’re drinking from the fire-hose!
+
+
+#### Goals:
+- Make the new hire feel welcome and happy.
+- Help the new hire become productive as soon as possible.
+- Explain how we work.
+  - (e.g. use pull requests, use GitHub, test) and what technologies we prefer, in order to avoid people going off on their own and implementing workflows that are incompatible with the rest of the department.
+
+
+
+Note: As a mentor, your responsibility is to help the new hire to go through the [New Staff Checklist](https://consul.stanford.edu/display/DSG/New+Staff+Checklist), which has additional admin info that applies to all new DLSS hires.
+
+## Pre-arrival
+- SUnet ID
+- Laptop (at least 2 weeks lead time, requires manager approval)
+- Schedule appointment for door access via Stanford ID
+- Get physical equipment ready. This includes desk, chair, monitor, etc
+- Appoint a mentor
+- Assign the developer to a team. New developers should not be left to work on a project alone.
+- Ensure that both the mentor and the supervisor of the new hire are present for their first day.
+
+## Ongoing Tasks
+- [__Pair programming__](https://github.com/sul-dlss/DeveloperPlaybook/blob/master/best-practices/pair_programming.md)
+- Check in at least twice a day
+- Taking the new hires to meetings & standups
+- Ensure they can find lunch
+- Take notes on onboarding process (mentor and mentee)
+- Check in often ( “How’s it going? What can I help you with? What are you having trouble with?” )
+
+## Weeks 1-2
+##### Accounts (first couple days)
+- GitHub sul-dlss (dlss-labs if necessary)
+- Honeybadger
+- New Relic  - Ops
+- Slack (#software-developers)
+- Consul - Ops
+- JIRA - Ops
+- k5users for starter projects?
+- Workgroups
+- List servs (dlss-developers@lists.stanford.edu)
+- Google Drive / team drives
+- Box
+- Zoom
+
+##### Processes
+- __Remote hires__: introduce to remote co-worker to talk about travel policies and expense reporting
+- Office 365 / calendaring / how to book rooms
+- Dev environment
+    - text editor
+    - Rubocop linter
+    - ruby version manager
+    - ssh config / kinit
+    - VPN
+  - kerb/ssh setup: https://consul.stanford.edu/display/dlssdev/New+Developer+Setup
+  - Ruby on mac setup: https://gorails.com/setup
+- Go to bookstore to buy peripherals (show them PCard docs)
+- Meet with Expert Partner (EP) and get run down of encryption/configuration
+- Meet department admin (Jib K.)
+- Flavor of Agile Methodology (set norms for standup, retro, planning)
+
+
+## Weeks 3-4
+##### Meetings / Introductions (short introduction to team’s work and a tour of where they sit)
+- [Digital Academy](https://consul.stanford.edu/display/SDR3/DLSS+Digital+Academy)
+- Jeremy’s history of cataloging: https://jermnelson.github.io/intro-library-tech/
+- Dev teams (Access, Infrastructure) (developers playbook)
+- Library systems
+- LOCKSS
+- PSM
+- Ops  (Review "to production" checklist, devops docs, puppet, nagios, monitoring, okcomputer, capistrano, travis, coveralls, honeybadger, shared_configs, gemnasium, SLAs)
+Digitization Services
+- Metadata
+- Digitization Lab Tour (Green Library Visit)
+##### Processes
+- Overview of department meetings: Agile Groove, SprintOps, CodeClub, Developers Forum
+- Overview of SUL open source communities (Samvera, Code4lib, Blacklight)
+
+## Weeks 5-6
+- Schedule onboarding retrospective
+- Add [retrospective notes](https://consul.stanford.edu/pages/viewpage.action?title=Developer+Onboarding&spaceKey=DSG) to Consul. (Create a new child page)
+- Suggest attending an upcoming conference (e.g. SamveraConnect, code4lib NorCal)
+- Suggest some uses for STAP funds (e.g. Upcase, conference registration)
+- Transition to independent work
+
+## Other resources:
+https://about.gitlab.com/handbook/general-onboarding/
+(GitLab has an onboarding survey to be completed after 60 days)
+
+https://blog.intercom.com/quip-edmond-lau-the-effective-engineer/
+(the last section contains some good onboarding ideas)
+
+https://slack.engineering/how-slack-supports-junior-engineers-89f6dcfe74a1
+(interesting post from a fairly new engineer at Slack about their mentoring process)


### PR DESCRIPTION
Moving developer on-boarding docs to Github from Consul. 
