### PR TITLE
Update deprecation guide

### DIFF
--- a/best-practices/deprecation.md
+++ b/best-practices/deprecation.md
@@ -5,5 +5,5 @@
 - Is the project deployed to any machines? If so, make an [operations-tasks](https://github.com/sul-dlss/operations-tasks) ticket to decommission the machine.
 - Is the project a dependency or service used by other sul-dlss projects?
 - If the project is a gem, update the gem's description on RubyGems (e.g. DEPRECATED: this gem is no longer being supported)
-- Move the repo to [sul-dlss-deprecated](https://github.com/sul-dlss-deprecated) ownership -- **NOTE** that you cannot move a private repo to the `sul-dlss-deprecated` org, in which case you can make the repo public first if appropriate or you can skip to the next step
+- Move the repo to [sul-dlss-deprecated](https://github.com/sul-dlss-deprecated) ownership 
 - Consider [archiving the repository](https://help.github.com/articles/archiving-a-github-repository/)


### PR DESCRIPTION
Remove the note about orgs using the free tier of GitHub not being able to have private repositories. This is now possible.