### PR TITLE
Adds more Slack channels to monitor for First Responder

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -118,7 +118,14 @@ Other places to monitor:
 * feedback email lists, e.g. argo-feedback, sinopia-feedback, etc
 * the `#dlss-infrastructure` channel
 * the `#sul-cap-collab` channel, which has developers in the School of Medicine working on the Profiles project (which we connect to with our sul-pub system)
-* Slack channels relevant to applications in the portfolio, e.g. `#pre-assembly`
+* Slack channels relevant to applications in the portfolio: 
+  - `#pre-assembly` 
+  - `#dlss-aaas`
+  - `#dlss-argo-dev` 
+  - `#dlss-etds-dev`
+  - `#dlss-preservation-dev`
+  - `#dlme`
+  - `#sdr-operations` 
 * Resque dashboards  e.g.
   - robots
     - https://robot-console-prod.stanford.edu/overview


### PR DESCRIPTION
I wasn't aware of a one of the channels existed until @peetucket mentioned an error report during standup.