### PR TITLE
Update 1st responder doc per last week's team mtg

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -1,7 +1,6 @@
 # Guide for Infrastructure Team First Responder
 
-The DLSS Infrastructure team is using a rotating role of "first responder." This doc explains the concept of
-the first responder role and outlines specific duties and expectations.
+The DLSS Infrastructure team is using a rotating role of "first responder." This doc explains the concept of the first responder role and outlines specific duties and expectations.
 
 ## Table of Contents
 
@@ -91,7 +90,7 @@ If you need to triage or troubleshoot a problem and realize some documentation i
 * README or other top level markdown doc in codebase (viewable via github)
   * Which codebase would need to be apparent from the problem
 * Wiki for the codebase
-* ? - in general, just try to consider where the person interested in the info might look first. A user might go to the wiki, a dev might go to the README, ops folks might head to DevOpsDocs. Use your best judgement and ask for feedback if unsure.
+* ? - in general, consider where the person interested in the info might look first. An end-user might go to the wiki, a dev might go to the README, ops folks might head to DevOpsDocs. Use your best judgement and ask for feedback if unsure.
 
 The above documents should be useful and current. Please submit improvements as PRs for review.
 
@@ -112,7 +111,7 @@ We need this document to be useful and current.  Please submit improvements as P
 At the very least, the first responder should be watching:
 
 * [Honeybadger alerts](https://app.honeybadger.io/projects) for projects in the Infrastructure portfolio
-  * **Note** that you may want to clear old alerts at the beginning of your first responder shift so you have a clean slate to monitor.
+  * **Note** that you may want to resolve old alerts in the Honeybadger UI at the beginning of your first responder shift so you have a clean slate to monitor.
 * Feedback email lists, e.g. argo-feedback, sinopia-feedback, etc
 * Slack channels relevant to applications in the portfolio:
   - `#dlme` - "Digital Library of the Middle East" - we are responsible for dlme-transform, related to indexing of materials.
@@ -128,7 +127,6 @@ At the very least, the first responder should be watching:
   - `#sul-cap-collab` - has developers in the School of Medicine working on the Profiles project (which we connect to with our sul-pub system)
   - `#web-archiving`
 * Queue dashboards:
-  - **Note** that you may want to clear old failed jobs at the beginning of your first responder shift so you have a clean slate to monitor, but do this deliberately and with caution: clearing failed jobs may prevent investigating current known first responder issues.
   - robots
     - https://robot-console-prod.stanford.edu/overview
       - https://robot-console-prod.stanford.edu/failed

--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -1,9 +1,7 @@
 # Guide for Infrastructure Team First Responder
 
-The DLSS infrastructure team is using a rotating role of "first responder".  This doc explains a bit about the concept of
-the first responder role and then outlines specific duties and expectations.
-
-PRs to this doc are always welcome, but especially while we're ironing things out and having regular retrospectives about the process.  If it sticks, and/or the access team adopts it, we can get rid of this caveat.
+The DLSS Infrastructure team is using a rotating role of "first responder." This doc explains the concept of
+the first responder role and outlines specific duties and expectations.
 
 ## Table of Contents
 
@@ -26,7 +24,7 @@ PRs to this doc are always welcome, but especially while we're ironing things ou
   * [A note on prioritization](#a-note-on-prioritization)
 * [What if first responder isn't available?](#what-if-first-responder-isnt-available)
 
-# "First Responder" Rotation Premises
+## "First Responder" Rotation Premises
 
 * Respond to production issues in a timely fashion during business hours.
 * Single process for handling questions outside the team's current work cycle.
@@ -37,85 +35,85 @@ PRs to this doc are always welcome, but especially while we're ironing things ou
 
 ### "First Responder" != "On Call"
 
-* The idiosyncratic name of the role is intentional.  It is not the duty of the "first responder" to be on-call outside of the first responder's normal work hours (which may not line up exactly with business hours in Palo Alto).  The first responder rotation is an effort to watch and triage production issues in an intentional and organized fashion, since no engineer was officially assigned this responsibility in the past, and such minding of things was haphazard.
+The idiosyncratic name of the role is intentional. It is not the duty of the first responder to be on-call outside of the first responder's normal work hours (which may not line up exactly with business hours in Palo Alto). The first responder rotation is an effort to watch and triage production issues in an intentional and organized fashion, since no engineer was officially assigned this responsibility in the past, and such minding of things was haphazard.
 
-# Duties
+## Duties
 
-## Weekly Dependency Updates
+### Weekly Dependency Updates
 
-### Ensure dependency update spreadsheet is created
+#### Ensure dependency update spreadsheet is created
 
 Instructions are here https://docs.google.com/spreadsheets/d/1LysSAPFsRGt9PteWpVswp74xnPXyLLxADpHRfh69VLQ/edit#gid=0
 
 It *may* be that someone in a time zone further east than Palo Alto has already done this, but it is the first responder's responsibility to ensure this gets done.
 
-### Ensure Monday dependency updates are completed
+#### Ensure Monday dependency updates are completed
 
-It is a team task to complete these updates, but the first responder needs to make sure that all codebases needing updates have updates merged and deployed.  Note that some projects need to have PRs created by hand ("Manually clone and update repos that failed bundle update" on line 6 of instructions). It may be helpful to post in channel how many updates each developer should do, given who is working that day and how many PRs there are.
+It is a team task to complete these updates, but the first responder needs to make sure that all codebases needing updates have updates merged and deployed. Note that some projects may need to have PRs created by hand. It may be helpful to post in the `#dlss-infrastructure` Slack channel how many updates each developer should do, given who is working that day and how many PRs there are.
 
-#### Code that isn't a Ruby Application
+##### Code that isn't a Ruby Application
 
-We have code bases to maintain that aren't Ruby applications or gems.  We have not yet tackled how to deal with these.
+We have codebases to maintain that aren't Ruby applications or gems. We have not yet settled on a long-term method for dealing with these:
 
-- javascript node apps with npm updates:
-  - https://github.com/sul-dlss/access-update-scripts has code to create PRs for npm package updates, but it currently only works for the sul-dlss github organization.  All the sinopia code is in the LD4P github organization.  Should make a maintenance ticket to address this?
-- java code
-- other
+- javascript apps with npm updates:
+  - https://github.com/sul-dlss/access-update-scripts has code to create PRs for npm package updates, but it currently only works for the sul-dlss github organization. All the sinopia code is in the LD4P github organization. There is a [pending pull request](https://github.com/sul-dlss/access-update-scripts/pull/82) that will address this.
+- java code (note that we are down to two Java repositories in our platform: [suri2](https://github.com/sul-dlss/suri2) (which is slated to be replaced with the Rails-based [suri_rails](https://github.com/sul-dlss/suri_rails) in 2020), and [etd-reporter](https://github.com/sul-dlss/etd-reporter).)
+- Go projects (such as various RIALTO components)
 
-Note that security updates affecting our ruby gems will be caught when doing capistrano deployments via `gemfile audit`.
+Note that security updates affecting our Ruby **gems** will be caught when doing capistrano deployments via `gemfile audit`.
 
-## Verify / Notify Coverage for Following Week
+### Verify / Notify Coverage for Following Week
 
-1. Verify first responder for following week is still able to cover it.  Check this with on deck person on Monday (and keep in mind throughout the week, e.g. if person becomes ill).  (schedule: https://docs.google.com/spreadsheets/u/1/d/13TJR93Yc9_eF5B7w4XDx6ggG_wb3aLkgCHjpLwmHPBA/)
-  1. It's the scheduled responder's responsibility to find a swap, not current first responder. _TBD: We'll figure something out if said responder is unavailable due to emergency?_
+1. Verify first responder for following week is still able to cover it. Check this with on deck person on Monday (and keep in mind throughout the week, e.g., if person becomes ill).  (schedule: https://docs.google.com/spreadsheets/u/1/d/13TJR93Yc9_eF5B7w4XDx6ggG_wb3aLkgCHjpLwmHPBA/)
+  1. It's the scheduled responder's responsibility to find a swap, not current first responder.
   1. The person covering the following week is "on deck" for this week.
 1. Set Slack reminders in `#dlss-infrastructure` for next week's Monday morning. The reminders should indicate who is first responder and who is on deck for that week, and should be set for 3 am Pacific time/6 am Eastern, so that the east coast early risers don't have to wait for it.
-  * documentation on Slack's `/remind` command:  https://get.slack.help/hc/en-us/articles/208423427-Set-a-reminder
-    * e.g. if Alice and Bob are up next week, `/remind #dlss-infrastructure on Monday at 3 am "@alice is the first responder this week, and @bob is on deck"`
+  * Documentation on Slack's `/remind` command:  https://get.slack.help/hc/en-us/articles/208423427-Set-a-reminder
+    * E.g., if Alice and Bob are up next week, `/remind #dlss-infrastructure on Monday at 3 am "@alice is the first responder this week, and @bob is on deck"`
 
-## Sign Up for Your Next First Responder Shift
+### Sign Up for Your Next First Responder Shift
 
 The infrastructure team has 8 developers, so you should be taking a shift every 8 or so weeks.
-* schedule:  https://docs.google.com/spreadsheets/u/1/d/13TJR93Yc9_eF5B7w4XDx6ggG_wb3aLkgCHjpLwmHPBA/
+* Schedule:  https://docs.google.com/spreadsheets/u/1/d/13TJR93Yc9_eF5B7w4XDx6ggG_wb3aLkgCHjpLwmHPBA/
 
-## Proactively Check for Production Problems
+### Proactively Check for Production Problems
 
 See [How to Proactively Check for Production Problems](#how-to-proactively-check-for-production-problems) section below for specifics.
 
-## Triage Production Problems
+### Triage Production Problems
 
-If a user reports a problem, or if one is surfaced from monitoring, the first responder is meant to timebox an investigation of the problem (_TBD: 30 min?_).  See [How to Triage Production Problems](#how-to-triage-production-problems) section below for more specifics.
+If a user reports a problem, or if one is surfaced from monitoring, the first responder ought to timebox an investigation of the problem (_TBD: 30 min?_). See [How to Triage Production Problems](#how-to-triage-production-problems) section below for more specifics.
 
-## Improve Troubleshooting Documentation as Needed
+### Improve Troubleshooting Documentation as Needed
 
-If you need to triage or troubleshoot a problem and realize some documentation is missing, please provide it.  List of appropriate places:
-* https://github.com/sul-dlss/DevOpsDocs - e.g. what an ops or devops person would need to know to handle the situation
+If you need to triage or troubleshoot a problem and realize some documentation is missing, please provide it. List of appropriate places:
+* https://github.com/sul-dlss/DevOpsDocs - e.g., what an ops or devops person would need to know to handle the situation
 * README or other top level markdown doc in codebase (viewable via github)
   * Which codebase would need to be apparent from the problem
 * Wiki for the codebase
-* ? - in general, just try to consider where the person interested in the info might look first.  A user might go to the wiki, a dev might go to the README, ops folks might head to DevOpsDocs.  Use your best judgement and ask for feedback if unsure.
+* ? - in general, just try to consider where the person interested in the info might look first. A user might go to the wiki, a dev might go to the README, ops folks might head to DevOpsDocs. Use your best judgement and ask for feedback if unsure.
 
-The above documents should be useful and current.  Please submit improvements as PRs for review.
+The above documents should be useful and current. Please submit improvements as PRs for review.
 
 If for some reason documentation is a significant undertaking, the call for documentation can be filed as an issue and prioritized/resourced by management.
 
-## Improve First Responder Instructions as Needed
+### Improve First Responder Instructions as Needed
 
 We need this document to be useful and current.  Please submit improvements as PRs for review.
 
-## Other Duties as Assigned
+### Other Duties as Assigned
 
 * Management may choose to have the first responder handle a non-project work ticket
   * If so, ensure you assign the ticket to yourself and put it in the "in progress" column the project board https://github.com/orgs/sul-dlss/projects/1
 * First responder may be asked to spearhead a work estimate https://github.com/sul-dlss-labs/estimation (note that these are, by definition, meant to be done by more than one person; if it's smaller, should it be a ticket in a project?)
 
-# How to Proactively Check for Production Problems
+## How to Proactively Check for Production Problems
 
-At the very least, the first responder should be watching incoming alerts from Honeybadger.  (https://app.honeybadger.io/projects)
+At the very least, the first responder should be watching:
 
-Other places to monitor:
-* Nagios alerts (https://sul-nagios-prod.stanford.edu/nagios/  The Services tab on the left column will give overview of checks.  The Problems->Services tab will give you what’s alerting.)
-* feedback email lists, e.g. argo-feedback, sinopia-feedback, etc
+* [Honeybadger alerts](https://app.honeybadger.io/projects) for projects in the Infrastructure portfolio
+  * **Note** that you may want to clear old alerts at the beginning of your first responder shift so you have a clean slate to monitor.
+* Feedback email lists, e.g. argo-feedback, sinopia-feedback, etc
 * Slack channels relevant to applications in the portfolio:
   - `#dlme` - "Digital Library of the Middle East" - we are responsible for dlme-transform, related to indexing of materials.
   - `#dlss-aaas` - "Accessioning as a Service" - where accessioneers may surface problems
@@ -129,7 +127,8 @@ Other places to monitor:
   - `#sdr-operations`
   - `#sul-cap-collab` - has developers in the School of Medicine working on the Profiles project (which we connect to with our sul-pub system)
   - `#web-archiving`
-* Resque dashboards  e.g.
+* Queue dashboards:
+  - **Note** that you may want to clear old failed jobs at the beginning of your first responder shift so you have a clean slate to monitor, but do this deliberately and with caution: clearing failed jobs may prevent investigating current known first responder issues.
   - robots
     - https://robot-console-prod.stanford.edu/overview
       - https://robot-console-prod.stanford.edu/failed
@@ -141,16 +140,20 @@ Other places to monitor:
       - https://preservation-catalog-prod-01.stanford.edu/resque/failed
   - web-registrar-app
     - https://was-registrar-app.stanford.edu/queues
-* Other dashboards of interest:
   - dor-services-app sidekiq (for jobs run by workers in other threads):
     - https://dor-services-prod.stanford.edu/queues/
 * cron daemon emails
-* Github security alerts
+* GitHub security alerts
+
+As a loose guideline, we recommend checking each of these at least once or twice a day to stay on top of potential issues.
+
+Other places to monitor:
+* Nagios alerts (https://sul-nagios-prod.stanford.edu/nagios/  The Services tab on the left column will give overview of checks.  The Problems->Services tab will give you what’s alerting.)
 * If you hear about possible security issues through other avenues (e.g. `#iso-public` on Slack, your consumption of the news in general), and you feel that the issues may be relevant and uncaptured, file an issue and call attention to it as needed.
 
-# How to Triage Production Problems
+## How to Triage Production Problems
 
-If a user reports a problem, or if one is surfaced from monitoring, the first responder is meant to timebox an investigation of the problem (_TBD: no more than 30 min?_).  It's fine to ask teammates with relevant expertise for help, but also think about what documentation is needed so the next person will need less help. It is _not_ the job of the first responder to fix the issue on the spot (though if the fix is trivial, it's fine to do so).
+If a user reports a problem, or if one is surfaced from monitoring, the first responder is meant to timebox an investigation of the problem (_TBD: no more than 30 min?_). It's fine to ask teammates with relevant expertise for help, but also think about what documentation is needed so the next person will need less help. It is _not_ the job of the first responder to fix the issue on the spot (though if the fix is trivial, it's fine to do so).
 
 * All problems investigated should get a ticket UNLESS:
   * Investigation leads to discovery that there is no problem
@@ -164,7 +167,7 @@ If a user reports a problem, or if one is surfaced from monitoring, the first re
 
 ### A note on prioritization
 
-Prioritization is the responsibility of management, not the responsibility of the first responder.  Though of course, if a developer becomes aware of what may be a high priority issue, and is unsure whether management is aware of the issue (or sufficiently aware of its severity), the developer is certainly encouraged to bring the issue to their manager's attention.
+Prioritization is the responsibility of management, not the responsibility of the first responder. Though of course, if a developer becomes aware of what may be a high priority issue, and is unsure whether management is aware of the issue (or sufficiently aware of its severity), the developer is certainly encouraged to bring the issue to their manager's attention.
 
 * Types of data to help with prioritization
   * Is this a significant production problem? A non-critical outage?
@@ -173,8 +176,8 @@ Prioritization is the responsibility of management, not the responsibility of th
   * How many digital resources are affected?
   * Is it blocking time sensitive work?
 
-# What if first responder isn't available?
+## What if first responder isn't available?
 
 The idea is for the first responder to be "interruptible" for production problems during his/her week of coverage.  If there are significant blocks of time when this isn't true (e.g. ½ day meeting with no access to slack or email), or if life happens (illness, family emergency, etc.), hopefully the first responder can arrange for coverage.  ("I'll take one of your days if you can cover Tues for me").  Please notify `#dlss-infrastructure` Slack channel of changes.
 
-When the first responder can't arrange for coverage, the default would be for the "on deck" responder to become first responder.  The "on deck" person is the first responder for the following week.
+When the first responder can't arrange for coverage, the default would be for the "on deck" responder to become first responder. The "on deck" person is the first responder for the following week.


### PR DESCRIPTION
* Tidy the text a bit to be more succinct
* Re-balance the header levels to be a single hierarchy
* Update documentation around FR's queue and honeybadger monitoring responsibilities