### PR TITLE
note exceptions to verify deployments for special projects

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -66,6 +66,18 @@ Note that you will need to be sure you can ssh into each of the VMs from whereve
     - take note in #dlss-infra-stage-use if there is active testing going on;  be sure to either comment out that app or coordinate with tester
 - prod: if all tests passed for stage deploys, deploy to prod with script.
 
+Note that the deployment script will attempt to verify the status check URL for projects that have one and will report success or failure for each project.
+There are currently two projects which cannot be verified in production since those servers are locked down and do not allow external requests (even on full tunnel VPN).
+These projects are `suri_rails` and `workflow-server-rails`.  To verify deployment, you can visit Honeybadger and curl from the servers:
+
+Honeybadger:
+- Workflow server rails: https://app.honeybadger.io/projects/58890/deploys
+- Suri : https://app.honeybadger.io/projects/70269/deploys
+
+Status check from the server (ssh into the prod server for that project and then use curl):
+- Workflow server rails: `curl -i https://workflow-service-prod.stanford.edu/status/all`
+- Suri: `curl -i https://sul-suri-prod.stanford.edu/status/all`
+
 ###### Important Exceptions
 
 There are applications that need to be deployed separately (i.e., not using `sdr-deploy`):


### PR DESCRIPTION
See https://github.com/sul-dlss/sdr-deploy/pull/29

Two projects cannot be verified by the deploy script automatically and need to be verified manually.