### PR TITLE
touchups to testing guidance

### DIFF
--- a/best-practices/testing.md
+++ b/best-practices/testing.md
@@ -1,15 +1,42 @@
 # Testing
 
+## Why?
+
 Testing helps show how the code was intended to be used, proves that it works for
 the important cases, and prevents future developers from introducing regressions.
 Having a good test suite enables us to refactor the code without worrying that
-we're going to break something.  Every feature addition should be submitted with
-at least one test.
+we're going to break something.
+
+## When?
+
+Every feature addition should be submitted with at least one (meaningful\*) test. Ideally,
+all modified code should be tested (i.e., we aim for "diff coverage" of 100%). Even when
+the intent isn't to modify behavior (e.g. a "pure refactoring" to pave the way for further
+changes or to allow code re-use), it's possible to introduce regressions. In some cases,
+existing code won't have tests, or the tests will be overly implementation specific. In those
+cases we should prefer to pay down technical debt by writing better/any tests for such code,
+but we also recognize time doesn't always permit this, or that time may not permit thorough
+test writing in parallel with the code change (as in the case of an easily code reviewed fix
+for an urgent production issue). Use your judgement, and leave an explanation on the PR if
+test coverage could be better (maybe file an issue, too).
+
+## How?
+
+### Ruby
 
 Ruby projects in DLSS should use the [RSpec](https://rspec.info/) framework for testing.
 There is a `rspec-rails` gem for integrating with Rails projects. Much of the [Blacklight](http://projectblacklight.org/) and [Samvera](https://samvera.org/)
 community have chosen to use RSpec; we should be consistent unless there is a reason not to.
 
+### JavaScript
+
 JavaScript should also be tested, but the multitude of javascript of testing libraries
-can be daunting.  Take a look at https://medium.com/welldone-software/an-overview-of-javascript-testing-in-2018-f68950900bc3
+can be daunting.  Take a look at https://medium.com/welldone-software/an-overview-of-javascript-testing-7ce7298b9870
 for a concise guide.
+
+Note that a couple of JS projects to which we contribute heavily (thus providing a snapshot of our current JS testing
+approaches) are not in the [sul-dlss](https://github.com/sul-dlss/?q=&type=&language=javascript) org:
+* https://github.com/ProjectMirador/mirador/
+* https://github.com/LD4P/sinopia_editor/
+
+\* "What is a meaningful test?" is currently out of scope for this markdown document 🙂

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -48,7 +48,11 @@ Having Your Code Reviewed
 Reviewing Code
 --------------
 
-Understand why the code is necessary (bug, user experience, refactoring). Then:
+* Understand why the code is necessary (bug, user experience, refactoring).
+* Read the code change, considering both the code that does the thing(s), and any testing
+of said code (whether unit, integration, manual, or otherwise -- see also [testing.md](../best-practices/testing.md)).
+
+Then:
 
 * Communicate which ideas you feel strongly about and those you don't.
 * Identify ways to simplify the code while still solving the problem.

--- a/code-review/guidelines.md
+++ b/code-review/guidelines.md
@@ -24,7 +24,7 @@
     * according to personal judgment
   * evaluate test coverage of the proposed changes
     * suggest areas where coverage may be improved
-  * evaluate changes in overall test coverage
+  * evaluate changes in overall test coverage.  strive for full coverage of modified code when making changes (see [testing.md](../best-practices/testing.md)).
 * be aware there are situations where the above guidelines may be bypassed
 * think of requests for changes in terms of “must do” “should do” and “would be nice to do”
 * collaborate with code authors to improve the code

--- a/code-review/tools.md
+++ b/code-review/tools.md
@@ -2,12 +2,12 @@
 
 ## Tools
 
-* Continuous integration tools automatically ensure the tests pass (e.g. travis, jenkins)
+* Continuous integration tools automatically ensure the tests pass (e.g. CircleCI, Travis, Jenkins)
 * Test coverage tools can inform QA/verifiability, reflecting the relative completeness of test/CI results (e.g. coveralls, code cov, code climate)
 * Documentation coverage tools can inform documentation extent (e.g. inch)
-* Doc tools can detect formal documentation errors (e.g. yard)
-* Audit tools can inform security analysis, including across the dependency tree (e.g. bundle_audit, gemnasium)
+* Doc tools can detect formal documentation errors (e.g. yard, openapi_parser)
+* Audit tools can inform security analysis, including across the dependency tree (e.g. bundle_audit, github security alerts, brakeman)
 * Static analysis can detect both flaws/deprecations and style-compliance (e.g. rubocop, code climate, reek)
-* Style tools can normalize logically equivalent expressions into fewer conventional forms (e.g. linters, rubocop)
+* Style tools can normalize logically equivalent expressions into fewer conventional forms (e.g. linters such as rubocop or eslint)
 
 In ALL cases, the uses of these tools (configs, example invocations, etc.) should be explicitly documented as part of the project.  (e.g. README, badges …)


### PR DESCRIPTION
* indicate that we'd prefer 100% diff coverage for modified code, when possible
  * add structure to testing best practices doc
* mention diff coverage testing advice in other places that give testing guidance, link to testing best practices doc
* freshen up testing related links and tool mentions

this came out of some discussion in an infrastructure team planning meeting in late july, where we were considering some unexpected breakages that resulted from refactoring code without existing tests.