### PR TITLE
Add link to pres_cat wiki for investigation

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -179,6 +179,7 @@ At the very least, the first responder should be watching:
   - preservation
     - https://preservation-catalog-prod-01.stanford.edu/resque/overview
       - https://preservation-catalog-prod-01.stanford.edu/resque/failed
+        - When debugging pres_cat errors: https://github.com/sul-dlss/preservation_catalog/wiki/Investigating-failed-Resque-Jobs
   - web-registrar-app
     - https://was-registrar-app.stanford.edu/queues
   - dor-services-app sidekiq (for jobs run by workers in other threads):


### PR DESCRIPTION
@sul-dlss/infrastructure-team - a small update to add link to the pres_cat wiki when investigating zip errors.