### PR TITLE
amend dependency update deployment instructions

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -55,8 +55,10 @@ Use the `sdr-deploy` script to deploy all infrastructure projects (with **import
 Note that you will need to be sure you can ssh into each of the VMs from wherever you are running the deploy script.
 
 - qa: deploy to qa with script
-- stage: please run infrastructure-integration-tests before deploy to stage, then deploy to stage with script, then run tests after deploy to stage.
-    - take note in #dlss-infra-stage-use if there is active testing going on;  be sure to either comment out that app or coordinate with tester
+- stage: deploy to stage with script, then run infrastructure-integration-tests after deploy to stage.
+  - It's possible that individual tests will fail due to random network connection issues, and chances are not great that the full suite will pass in one go from a spotty off-campus connection.
+    - If a failed test passes upon retry against the same set of deployed codebases, that's fine.  If you're unsure whether a particular test failure indicates bad network luck, a regression in the application, or an out of date test, raise it for discussion (or another dev to retry from their laptop) in #dlss-infrastructure.
+  - before deploying, warn #dlss-infra-stage-use in case there is active testing going on;  be sure to either comment out that app or coordinate with tester
 - prod: if all tests passed for stage deploys, deploy to prod with script.
 
 Note that the deployment script will attempt to verify the status check URL for projects that have one and will report success or failure for each project.


### PR DESCRIPTION
per discussion in slack, it's hard to get a true baseline where the only difference is the dependency updates (because we don't have a pre-update tag, and because non-`main` test branches may have been deployed to stage throughout the prior week).  so amend instructions suggest running one post-deployment test and discussing possible regressions in chat.

also, a bit of advice on running the test suite and when to consider a test genuinely failed.