### PR TITLE
Remove reference to golang and RIALTO

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -105,8 +105,6 @@ We have codebases that aren't Ruby applications or gems. We have not yet settled
     * [openwayback](https://github.com/sul-dlss/openwayback)
     * [wasapi-downloader](https://github.com/sul-dlss/wasapi-downloader)
     * [WASMetadataExtractor](https://github.com/sul-dlss/WASMetadataExtractor)
-* Go projects (such as various RIALTO components)
-  * with the future of RIALTO in question, it's not likely to receive attention any time soon
 
 We currently do not have an automatic update mechanism for our Java projects.
 


### PR DESCRIPTION
Small update to remove the reference to Go (as it had been replaced in RIALTO already with python) and remove the reference to RIALTO as it is no where on our horizon for the foreseeable future.