### PR TITLE
Remove outdated status check information from FR docs

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -82,18 +82,6 @@ Finally, **warn #dlss-infra-chg-mgmt** of the impending deployment to prod, and 
 
 Next, turn off Google Books when deploying to production at https://sul-gbooks-prod.stanford.edu/features. This avoids failed deposit due to a temporary Cocina model mismatch. Unlike other applications, the deposits will fail without retry and require manual remediation.  Don't forget to re-enable when prod deployments are complete!
 
-Note that the deployment script will attempt to verify the status check URL for projects that have one and will report success or failure for each project.
-
-There are currently two projects which cannot be verified in production since those servers are locked down and do not allow external requests (even on full tunnel VPN). These projects are `suri_rails` and `workflow-server-rails`.  To verify deployment, you can visit Honeybadger and curl from the servers:
-
-Honeybadger:
-- Workflow server rails: https://app.honeybadger.io/projects/58890/deploys
-- Suri : https://app.honeybadger.io/projects/70269/deploys
-
-Status check from the server (ssh into the prod server for that project and then use curl):
-- Workflow server rails: `curl -i https://workflow-service-prod.stanford.edu/status/all`
-- Suri: `curl -i https://sul-suri-prod.stanford.edu/status/all`
-
 ### Run infrastructure-integration-tests
 
 We want the FR to ensure


### PR DESCRIPTION
I opted not to replace it with anything about Nagios since the deployment tool will automatically pop it open in your browser and let you know about it.