### PR TITLE
Move deploy to QA after deploy to prod

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -89,9 +89,9 @@ Then **run infrastructure-integration-tests** (see [documentation](#run-infrastr
 
 #### 5. Deploy to prod
 
-**Warn #dlss-infra-chg-mgmt** of the impending deployment to prod, and then deploy the tag you created above to prod using `sdr-deploy`.
+Next, **turn off Google Books when deploying to production** at https://sul-gbooks-prod.stanford.edu/features. This avoids failed deposit due to a temporary Cocina model mismatch. Unlike other applications, the deposits will fail without retry and require manual remediation.  
 
-Next, **turn off Google Books when deploying to production** at https://sul-gbooks-prod.stanford.edu/features. This avoids failed deposit due to a temporary Cocina model mismatch. Unlike other applications, the deposits will fail without retry and require manual remediation.  Don't forget to re-enable when prod deployments are complete!
+**Warn #dlss-infra-chg-mgmt** of the impending deployment to prod, and then deploy the tag you created above to prod using `sdr-deploy`.
 
 Note that the deployment script will attempt to verify the status check URL for projects that have one and will report success or failure for each project.
 
@@ -105,8 +105,7 @@ Status check from the server (ssh into the prod server for that project and then
 - Workflow server rails: `curl -i https://workflow-service-prod.stanford.edu/status/all`
 - Suri: `curl -i https://sul-suri-prod.stanford.edu/status/all`
 
-When deployment is complete,  **turn on Google Books again**.
-
+When deployment is complete, **turn on Google Books again**.
 
 #### 6. Deploy to QA
 

--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -87,11 +87,7 @@ Then, **warn #dlss-infra-stage-qa-use** of the impending deployment to stage in 
 
 Then **run infrastructure-integration-tests** (see [documentation](#run-infrastructure-integration-tests) below) after deploy to stage.
 
-#### 5. Deploy to QA
-
-Then, **warn #dlss-infra-stage-qa-use** of the impending deployment to QA in case there is active testing going on; if so, be sure to either comment out that app or coordinate with tester and then deploy the tag you created above to QA using `sdr-deploy`.
-
-#### 6. Deploy to prod
+#### 5. Deploy to prod
 
 Finally, **warn #dlss-infra-chg-mgmt** of the impending deployment to prod, and then deploy the tag you created above to prod using `sdr-deploy`.
 
@@ -110,6 +106,11 @@ Status check from the server (ssh into the prod server for that project and then
 - Suri: `curl -i https://sul-suri-prod.stanford.edu/status/all`
 
 When deployment is complete,  **turn on Google Books again**.
+
+
+#### 6. Deploy to QA
+
+To complete the cycle, and ensure QA has the common environment, deploy there as well. Then, **warn #dlss-infra-stage-qa-use** of the impending deployment to QA in case there is active testing going on; if so, be sure to either skip that app or coordinate with tester and then deploy the tag you created above to QA using `sdr-deploy`.
 
 ### Run infrastructure-integration-tests
 

--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -89,7 +89,7 @@ Then **run infrastructure-integration-tests** (see [documentation](#run-infrastr
 
 #### 5. Deploy to prod
 
-Finally, **warn #dlss-infra-chg-mgmt** of the impending deployment to prod, and then deploy the tag you created above to prod using `sdr-deploy`.
+**Warn #dlss-infra-chg-mgmt** of the impending deployment to prod, and then deploy the tag you created above to prod using `sdr-deploy`.
 
 Next, **turn off Google Books when deploying to production** at https://sul-gbooks-prod.stanford.edu/features. This avoids failed deposit due to a temporary Cocina model mismatch. Unlike other applications, the deposits will fail without retry and require manual remediation.  Don't forget to re-enable when prod deployments are complete!
 


### PR DESCRIPTION
Deploying to QA is less important than getting the changes out earlier in the day, which leaves more time for troubleshooting in case something goes wrong.  The only reason we really need a QA deploy is to reset the environment. It has no urgency.