### PR TITLE
Remove WordArray and SymbolArray cops from Rubocop template

### DIFF
--- a/style/infra_template.rubocop.yml
+++ b/style/infra_template.rubocop.yml
@@ -72,9 +72,4 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/NestedGroups:
   Max: 4 # default: 3
-
-Style/SymbolArray:
-  MinSize: 4 # default 2
-
-Style/WordArray:
-  MinSize: 4 # default 2
+  


### PR DESCRIPTION
Per @sul-dlss/infrastructure-team dev planning discussion, we want to keep the defaults for these rules.