### PR TITLE
Rename master to main where appropriate

### DIFF
--- a/best-practices/documentation/README.md
+++ b/best-practices/documentation/README.md
@@ -32,7 +32,7 @@ OpenAPI Specifications may be expressed as either YAML or JSON. Thus far, we hav
 
 Here are the steps we have been following:
 
-1. Create `openapi.yml`: feel free to copy from an existing project, paste, and adjust ([example](https://github.com/sul-dlss/technical-metadata-service/blob/master/openapi.yml))
+1. Create `openapi.yml`: feel free to copy from an existing project, paste, and adjust ([example](https://github.com/sul-dlss/technical-metadata-service/blob/main/openapi.yml))
 1. Validate `openapi.yml` in the CI build ([CircleCI example](https://github.com/sul-dlss/technical-metadata-service/blob/6c8151b1ca713061c227e8030f03c6531eee1093/.circleci/config.yml#L103-L114))
 1. Add OpenAPI validation badge to the README ([example](https://github.com/sul-dlss/technical-metadata-service/blob/6c8151b1ca713061c227e8030f03c6531eee1093/README.md#L5))
 1. Add Committee gem, which allows automagic validation of requests and responses based on your API specification, as a dependency ([example](https://github.com/sul-dlss/technical-metadata-service/blob/6c8151b1ca713061c227e8030f03c6531eee1093/Gemfile#L9))

--- a/best-practices/howto_readme.md
+++ b/best-practices/howto_readme.md
@@ -14,7 +14,7 @@ All projects should have a `README.md` file. This file should try to answer the 
       - [CircleCI](https://circleci.com/docs/2.0/status-badges/)
     - Current version (if a published package)
       - E.g., if Ruby: [Gem Version](http://badge.fury.io/for/rb)
-    - Test coverage 
+    - Test coverage
       - [CodeClimate](https://codeclimate.com/); or
       - Coveralls (though CodeClimate is preferred as of 2020)
     - Code quality
@@ -25,13 +25,13 @@ All projects should have a `README.md` file. This file should try to answer the 
       -  [Microbadger](https://microbadger.com/#badges)
 
 ## Example
-    [![Build Status](https://travis-ci.org/sul-dlss/name-of-the-project.svg?branch=master)](https://travis-ci.org/sul-dlss/name-of-the-project) 
+    [![Build Status](https://travis-ci.org/sul-dlss/name-of-the-project.svg?branch=main)](https://travis-ci.org/sul-dlss/name-of-the-project)
     [![Code Climate](https://codeclimate.com/github/sul-dlss/name-of-the-project/badges/gpa.svg)](https://codeclimate.com/github/sul-dlss/name-of-the-project)
-    [![Code Climate Test Coverage](https://codeclimate.com/github/sul-dlss/name-of-the-project/badges/badges/coverage.svg)](https://codeclimate.com/github/sul-dlss/name-of-the-project/badges/coverage) 
+    [![Code Climate Test Coverage](https://codeclimate.com/github/sul-dlss/name-of-the-project/badges/badges/coverage.svg)](https://codeclimate.com/github/sul-dlss/name-of-the-project/badges/coverage)
     [![Dependency Status](https://gemnasium.com/sul-dlss/name-of-the-project.svg)](https://gemnasium.com/sul-dlss/name-of-the-project) [![Gem Version](https://badge.fury.io/rb/name-of-the-project.svg)](http://badge.fury.io/rb/name-of-the-project)
-    [![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/name-of-the-project/master/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/name-of-the-project/master/openapi.yml)
+    [![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/name-of-the-project/main/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/name-of-the-project/main/openapi.yml)
     [![Docker image](https://images.microbadger.com/badges/image/suldlss/name-of-the-project.svg)](https://microbadger.com/images/suldlss/name-of-the-project "Get your own image badge on microbadger.com")
-    
+
     # Name of the Project
 
     This project provides an implementation of the [XKCD Random Number](https://xkcd.com/221/) generator. This random number generator is particularly useful when predictable random numbers can improve performance.
@@ -68,7 +68,7 @@ All projects should have a `README.md` file. This file should try to answer the 
     ```console
     $ rake
     ```
-    
+
 ## Other Examples
 
 - [spotlight](https://github.com/sul-dlss/spotlight)

--- a/best-practices/releasing_gems.md
+++ b/best-practices/releasing_gems.md
@@ -8,8 +8,8 @@ In DLSS, we practice [semantic versioning](http://semver.org) for our gems.
 
 ## Bundler tasks
 
-We use Bundler's rake tasks to release and push our gems. As long as the gem's Rakefile includes the following, 
-we have `build`, `install` and `release` Rake tasks available. 
+We use Bundler's rake tasks to release and push our gems. As long as the gem's Rakefile includes the following,
+we have `build`, `install` and `release` Rake tasks available.
 
 ```
 require 'bundler/gem_tasks'
@@ -27,7 +27,7 @@ In order for all of us to maintain and release our gems, we expect all new gems 
 $ gem owner base_indexer -a sul-devops-team@lists.stanford.edu
 ```
 
-The service account (`sul-devops-team@lists.stanford.edu`) will ensure we all have access to our collective work. 
+The service account (`sul-devops-team@lists.stanford.edu`) will ensure we all have access to our collective work.
 
 ### Adding/removing owners
 
@@ -37,6 +37,6 @@ See the [README](https://github.com/sul-dlss/rubygem-update-scripts/blob/master/
 
 ## Steps to release a new version of a gem
 
-1. Update the version of the gem in the default branch (typically `master`) according to the above [semantic versioning](http://semver.org) guidelines.
+1. Update the version of the gem in the default branch (typically `main`) according to the above [semantic versioning](http://semver.org) guidelines.
 1. Run `rake release` in the gem directory
 1. Add appropriate [release notes and publish the release](https://help.github.com/articles/creating-releases/)

--- a/best-practices/version_control.md
+++ b/best-practices/version_control.md
@@ -4,20 +4,20 @@ DLSS projects should be developed using a version control system, and, by defaul
 
 DLSS projects, by default, should be public repositories within the [sul-dlss](https://github.com/sul-dlss) organization. In the case of some multi-institutional projects or collaborative development, these projects may live in other organizations.
 
-By centralizing project hosting, it is easier for our colleagues to find and collaborate on our projects. 
+By centralizing project hosting, it is easier for our colleagues to find and collaborate on our projects.
 
 Projects should be public in order to share broadly with our colleagues at other institutions, who may learn from our approach (if not be able to run the code themselves) or offer useful critiques. Public repositories also encourage us to develop reusable code that follows best-practices around configuration and deployment.
 
 If a project must be private, the `README.md` should note why (and, ideally, follow the principle of "A reason is good when you can convince a teammate."). Good reasons to keep a project private include:
 
 - "Security concerns" about making the code public (not security by obscurity, but e.g. code migrated from legacy systems that may contain bad practices in the commit history)
- 
+
 ## Committing Ethos
 
 - Commit early, commit often. This is important both to ensure your work is safe, but also to get early feedback from colleagues.
-- Don't break master (and the corollary, don't push directly to master; use branches and pull requests in order to give continuous integration, etc a chance to run)
+- Don't break main (and the corollary, don't push directly to main; use branches and pull requests in order to give continuous integration, etc a chance to run)
 - Don't rewrite public history
-- Keep master releaseable. If you notice that it is broken (say, because of dependencies breaking), fix it.
+- Keep main releaseable. If you notice that it is broken (say, because of dependencies breaking), fix it.
 
 
 ## Commit Messages
@@ -27,17 +27,17 @@ Commits should have useful commit messages. A commit message is useful if it add
 > Why is this change necessary?
 >
 > This question tells reviewers of your pull request what to expect in the commit, allowing them to more easily identify and point out unrelated changes.
-> 
+>
 > How does it address the issue?
 >
 > Describe, at a high level, what was done to affect change. Introduce a red/black tree to increase search speed or Remove <troublesome gem X>, which was causing <specific description of issue introduced by gem> are good examples.
-> 
+>
 > If your change is obvious, you may be able to omit addressing this question.
-> 
+>
 > What side effects does this change have?
-> 
+>
 > This is the most important question to answer, as it can point out problems where you are making too many changes in one commit or branch. One or two bullet points for related changes may be okay, but five or six are likely indicators of a commit that is doing too many things.
-> 
+>
 > Your team should have guidelines and rules-of-thumb for how much can be done in a single commit/branch.
 > https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message
 

--- a/code-review/README.md
+++ b/code-review/README.md
@@ -1,7 +1,7 @@
 Code Review
 ===========
 
-Enthusiastically copied from https://github.com/thoughtbot/guides/blob/master/code-review/README.md
+Enthusiastically copied from https://github.com/thoughtbot/guides/tree/main/code-review/
 
 A guide for reviewing code and having your code reviewed.
 

--- a/developer_onboarding.md
+++ b/developer_onboarding.md
@@ -28,7 +28,7 @@ Note: As a mentor, your responsibility is to help the new hire to go through the
 - Ensure that both the mentor and the supervisor of the new hire are present for their first day.
 
 ## Ongoing Tasks
-- [__Pair programming__](https://github.com/sul-dlss/DeveloperPlaybook/blob/master/best-practices/pair_programming.md)
+- [__Pair programming__](/best-practices/pair_programming.md)
 - Check in at least twice a day
 - Taking the new hires to meetings & standups
 - Ensure they can find lunch


### PR DESCRIPTION
This commit doesn't remove ALL `master` references, because some of them are still hanging around (DevOpsDocs, exhibits, *-update-scripts).