### PR TITLE
Remove need to turn off/on google books for prod deploy

### DIFF
--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -43,6 +43,8 @@ If on a Mac, you will get better results if you stay in the same "space" as the 
 
 ##### 4. Deploy to prod
 
+NOTE: if you are also rolling out a new cocina-models update with the deployments, please [disable Google Books in production](https://sul-gbooks-prod.stanford.edu/features) before the deploy, and re-enable afterwards (notifying in the slack #google-books channel).  This avoids failed deposit due to a temporary Cocina model mismatch. Unlike other applications, the deposits will fail without retry and require manual remediation.
+
 1. **Warn #dlss-infra-chg-mgmt** of the impending deployment to prod.
 
 2. **Deploy the tag you created above to prod** using `sdr-deploy`.

--- a/infrateam_first_responder.md
+++ b/infrateam_first_responder.md
@@ -45,16 +45,12 @@ If on a Mac, you will get better results if you stay in the same "space" as the 
 
 1. **Warn #dlss-infra-chg-mgmt** of the impending deployment to prod.
 
-2. **Turn Off Google Books when deploying to production** at https://sul-gbooks-prod.stanford.edu/features. This avoids failed deposit due to a temporary Cocina model mismatch. Unlike other applications, the deposits will fail without retry and require manual remediation.
-
-3. **Deploy the tag you created above to prod** using `sdr-deploy`.
+2. **Deploy the tag you created above to prod** using `sdr-deploy`.
 
   Note that the deployment script will
   - pull the latest repo content from github
   - check cocina-model versions for agreement
   - open the Nagios dashboard for the environment
-
-4. **Turn On Google Books again** when deployment is complete and statuses are clear.
 
 ##### 5. Deploy to QA
 


### PR DESCRIPTION
Was told we don't need to do this anymore