### PR TITLE
Update CI and test coverage service links per 2025 usage

### DIFF
--- a/best-practices/howto_readme.md
+++ b/best-practices/howto_readme.md
@@ -10,15 +10,13 @@ All projects should have a `README.md` file. This file should try to answer the 
 - How to run the tests
 - Include relevant badges:
     - Build status
-      - [TravisCI](http://docs.travis-ci.com/user/status-images/); or
+      - [GitHub](https://github.com/features/actions); or
       - [CircleCI](https://circleci.com/docs/2.0/status-badges/)
     - Current version (if a published package)
       - E.g., if Ruby: [Gem Version](http://badge.fury.io/for/rb)
     - Test coverage
-      - [CodeClimate](https://codeclimate.com/); or
-      - Coveralls (though CodeClimate is preferred as of 2020)
-    - Code quality
-      - CodeClimate
+      - [CodeCov](https://app.codecov.io); or
+      - [CodeClimate](https://codeclimate.com/)
     - API validation (if project declares an HTTP API using the [OpenAPI Specification](http://spec.openapis.org/oas/v3.0.2))
       - [OpenAPI validator](http://validator.swagger.io/validator)
     - Docker image (if project publishes one or more docker images)

--- a/best-practices/setting_up_rails_projects.md
+++ b/best-practices/setting_up_rails_projects.md
@@ -14,8 +14,8 @@ Use the [config](https://github.com/railsconfig/config) gem for configuration ma
 ## Continuous Integration
 Projects should have implemented continuous integration. The following services are used often:
 
- - [travis-ci](https://travis-ci.com/) or [CircleCI](https://circleci.com/) for running test suites
- - [codeclimate](https://codeclimate.com/) for code coverage and code quality
+ - [GitHub](https://github.com/features/actions) or [CircleCI](https://circleci.com/) for running test suites
+ - [CodeCov](https://app.codecov.io) or [CodeClimate](https://codeclimate.com/) for test coverage
 
 ## Application Monitoring
 See [Monitoring](/best-practices/monitoring.md).

--- a/code-review/infrateam_prs.md
+++ b/code-review/infrateam_prs.md
@@ -2,13 +2,13 @@
 
 ## Pull Request Practices in the Infrastructure Team
 
-The Infrastructure Team uses the following practices with the goal of good communication around the status and needed actions for a PR. 
+The Infrastructure Team uses the following practices with the goal of good communication around the status and needed actions for a PR.
 
 * When reviewing a PR, change the PR assignee in GitHub to yourself. This allows others to be aware that the PR is receiving attention.  This does not mean that another developer cannot also review and comment on the PR at any point in its review, even after merging. Review by more than one developer is not wasted effort.
 * Unassign yourself if you find you are no longer able to give the PR attention.
 * Before merging a PR, make sure all PR assignees have submitted a review.
 * Edit the PR title to have a prefix of [HOLD] if the PR requires further action before being merged. These may include:
-  * The Product Owner needs to review and possibly test a deployment of the branch first. 
-  * Merging the PR is dependent on other actions. Indicate these in the comments in the PR. 
-* Remove the [HOLD] prefix before merging. This avoids the misperception that a PR that was supposed to be held was accidentally merged. 
-* Create a draft PR when the code is not ready for review. This is optional. Draft PRs provide the benefit of CircleCI testing and codeclimate checks as well as comment and discussion during development. Change the draft PR to Ready for Review when you would like code review and the PR to be merged. 
+  * The Product Owner needs to review and possibly test a deployment of the branch first.
+  * Merging the PR is dependent on other actions. Indicate these in the comments in the PR.
+* Remove the [HOLD] prefix before merging. This avoids the misperception that a PR that was supposed to be held was accidentally merged.
+* Create a draft PR when the code is not ready for review. This is optional. Draft PRs provide the benefit of continuous integration testing and test coverage checks as well as comment and discussion during development. Change the draft PR to Ready for Review when you would like code review and the PR to be merged.

--- a/code-review/tools.md
+++ b/code-review/tools.md
@@ -2,12 +2,12 @@
 
 ## Tools
 
-* Continuous integration tools automatically ensure the tests pass (e.g. CircleCI, Travis, Jenkins)
-* Test coverage tools can inform QA/verifiability, reflecting the relative completeness of test/CI results (e.g. coveralls, code cov, code climate)
+* Continuous integration tools automatically ensure the tests pass (e.g. CircleCI, GitHub Actions, Jenkins)
+* Test coverage tools can inform QA/verifiability, reflecting the relative completeness of test/CI results (e.g. CodeCov, CodeClimate)
 * Documentation coverage tools can inform documentation extent (e.g. inch)
 * Doc tools can detect formal documentation errors (e.g. yard, openapi_parser)
 * Audit tools can inform security analysis, including across the dependency tree (e.g. bundle_audit, github security alerts, brakeman)
-* Static analysis can detect both flaws/deprecations and style-compliance (e.g. rubocop, code climate, reek)
+* Static analysis can detect both flaws/deprecations and style-compliance (e.g. rubocop)
 * Style tools can normalize logically equivalent expressions into fewer conventional forms (e.g. linters such as rubocop or eslint)
 
 In ALL cases, the uses of these tools (configs, example invocations, etc.) should be explicitly documented as part of the project.  (e.g. README, badges …)


### PR DESCRIPTION
We tend to use GH Actions, CircleCI, or Jenkins for CI, and use either CodeCov or CodeClimate for test coverage. Travis and Coveralls are not a thing for us anymore.
